### PR TITLE
feat!: Support custom cache + Remove `ClientProvider.StartCacheJanitor` and `ClientProvider.StopCacheJanitor`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 TwiN
+Copyright (c) 2023 TwiN
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -110,18 +110,10 @@ You can also configure the client provider to cache the output of the function y
 clientProvider := g8.NewClientProvider(...).WithCache(ttl, maxSize)
 ```
 
-Since g8 leverages [TwiN/gocache](https://github.com/TwiN/gocache), you can also use gocache's 
-constants for configuring the TTL and the maximum size:
+Since g8 leverages [TwiN/gocache](https://github.com/TwiN/gocache) (unless you're using `WithCustomCache`), 
+you can also use gocache's constants for configuring the TTL and the maximum size:
 - Setting the TTL to `gocache.NoExpiration` (-1) will disable the TTL. 
 - Setting the maximum size to `gocache.NoMaxSize` (0) will disable the maximum cache size
-
-If you're using a TTL and have a lot of tokens (100k+), you may want to use `clientProvider.StartJanitor()` to allow 
-the cache to passively delete expired entries. If you have to re-initialize the client provider after the janitor has
-been started, make sure to stop the janitor first (`clientProvider.StopJanitor()`). This is because the janitor runs on 
-a separate goroutine, thus, if you were to re-create a client provider and re-assign it, the old client provider would 
-still exist in memory with the old cache. I'm only specifying this for completeness, because for the overwhelming 
-majority of people, the gate will be created on application start and never modified again until the application shuts
-down, in which case, you don't even need to worry about stopping the janitor.
 
 To avoid any misunderstandings, using a client provider is not mandatory. If you only have a few tokens and you can load
 them on application start, you can just leverage `AuthorizationService`'s `WithToken`/`WithTokens`/`WithClient`/`WithClients`.

--- a/authorization.go
+++ b/authorization.go
@@ -41,7 +41,6 @@ func NewAuthorizationService() *AuthorizationService {
 // if you plan to add multiple clients
 //
 // If you wish to configure advanced permissions, consider using WithClient instead.
-//
 func (authorizationService *AuthorizationService) WithToken(token string) *AuthorizationService {
 	authorizationService.mutex.Lock()
 	authorizationService.clients[token] = NewClient(token)

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,13 @@
+package g8
+
+import (
+	"github.com/TwiN/gocache/v2"
+)
+
+type Cache interface {
+	Get(key string) (value any, exists bool)
+	Set(key string, value any)
+}
+
+// Make sure that gocache.Cache is compatible with the interface
+var _ Cache = (*gocache.Cache)(nil)

--- a/clientprovider_test.go
+++ b/clientprovider_test.go
@@ -28,25 +28,25 @@ func TestClientProvider_GetClientByToken(t *testing.T) {
 
 func TestClientProvider_WithCache(t *testing.T) {
 	provider := NewClientProvider(getClientByTokenFunc).WithCache(gocache.NoExpiration, 10000)
-	if provider.cache.Count() != 0 {
+	if provider.cache.(*gocache.Cache).Count() != 0 {
 		t.Error("expected cache to be empty")
 	}
 	if client := provider.GetClientByToken("valid-token"); client == nil {
 		t.Error("expected client, got nil")
 	}
-	if provider.cache.Count() != 1 {
+	if provider.cache.(*gocache.Cache).Count() != 1 {
 		t.Error("expected cache size to be 1")
 	}
 	if client := provider.GetClientByToken("valid-token"); client == nil {
 		t.Error("expected client, got nil")
 	}
-	if provider.cache.Count() != 1 {
+	if provider.cache.(*gocache.Cache).Count() != 1 {
 		t.Error("expected cache size to be 1")
 	}
 	if client := provider.GetClientByToken("invalid-token"); client != nil {
 		t.Error("expected nil, got", client)
 	}
-	if provider.cache.Count() != 2 {
+	if provider.cache.(*gocache.Cache).Count() != 2 {
 		t.Error("expected cache size to be 2")
 	}
 	if client := provider.GetClientByToken("invalid-token"); client != nil {
@@ -60,52 +60,64 @@ func TestClientProvider_WithCache(t *testing.T) {
 func TestClientProvider_WithCacheAndExpiration(t *testing.T) {
 	provider := NewClientProvider(getClientByTokenFunc).WithCache(10*time.Millisecond, 10)
 	provider.GetClientByToken("token")
-	if provider.cache.Count() != 1 {
+	if provider.cache.(*gocache.Cache).Count() != 1 {
 		t.Error("expected cache size to be 1")
 	}
-	if provider.cache.Stats().ExpiredKeys != 0 {
+	if provider.cache.(*gocache.Cache).Stats().ExpiredKeys != 0 {
 		t.Error("expected cache statistics to report 0 expired key")
 	}
 	time.Sleep(15 * time.Millisecond)
 	provider.GetClientByToken("token")
-	if provider.cache.Stats().ExpiredKeys != 1 {
+	if provider.cache.(*gocache.Cache).Stats().ExpiredKeys != 1 {
 		t.Error("expected cache statistics to report 1 expired key")
 	}
 }
 
-func TestClientProvider_WithCacheAndJanitor(t *testing.T) {
-	provider := NewClientProvider(getClientByTokenFunc).WithCache(5*time.Millisecond, 10)
-	provider.GetClientByToken("token")
-	if provider.cache.Count() != 1 {
+type customCache struct {
+	entries map[string]any
+}
+
+func (c *customCache) Get(key string) (value any, exists bool) {
+	v, exists := c.entries[key]
+	return v, exists
+}
+
+func (c *customCache) Set(key string, value any) {
+	if c.entries == nil {
+		c.entries = make(map[string]any)
+	}
+	c.entries[key] = value
+}
+
+var _ Cache = (*customCache)(nil)
+
+func TestClientProvider_WithCustomCache(t *testing.T) {
+	provider := NewClientProvider(getClientByTokenFunc).WithCustomCache(&customCache{})
+	if len(provider.cache.(*customCache).entries) != 0 {
+		t.Error("expected cache to be empty")
+	}
+	if client := provider.GetClientByToken("valid-token"); client == nil {
+		t.Error("expected client, got nil")
+	}
+	if len(provider.cache.(*customCache).entries) != 1 {
 		t.Error("expected cache size to be 1")
 	}
-	provider.StartCacheJanitor()
-	keyExpiredWithinOneSecond := false
-	for start := time.Now(); time.Since(start) < time.Second; {
-		if provider.cache.Stats().ExpiredKeys == 1 {
-			keyExpiredWithinOneSecond = true
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	if client := provider.GetClientByToken("valid-token"); client == nil {
+		t.Error("expected client, got nil")
 	}
-	if !keyExpiredWithinOneSecond || provider.cache.Count() != 0 {
-		t.Error("expected janitor to delete expired key")
+	if len(provider.cache.(*customCache).entries) != 1 {
+		t.Error("expected cache size to be 1")
 	}
-	provider.StopCacheJanitor()
-}
-
-func TestClientProvider_StartCacheJanitorWhenTTLSetToNoExpiration(t *testing.T) {
-	provider := NewClientProvider(getClientByTokenFunc).WithCache(gocache.NoExpiration, 10)
-	err := provider.StartCacheJanitor()
-	if err != ErrNoExpiration {
-		t.Error("expected provider.StartCacheJanitor() to return ErrNoExpiration, got", err)
+	if client := provider.GetClientByToken("invalid-token"); client != nil {
+		t.Error("expected nil, got", client)
 	}
-}
-
-func TestClientProvider_StartCacheJanitorWhenCacheNotInitialized(t *testing.T) {
-	provider := NewClientProvider(getClientByTokenFunc)
-	err := provider.StartCacheJanitor()
-	if err != ErrCacheNotInitialized {
-		t.Error("expected provider.StartCacheJanitor() to return ErrCacheNotInitialized, got", err)
+	if len(provider.cache.(*customCache).entries) != 2 {
+		t.Error("expected cache size to be 2")
+	}
+	if client := provider.GetClientByToken("invalid-token"); client != nil {
+		t.Error("expected nil, got", client)
+	}
+	if client := provider.GetClientByToken("invalid-token"); client != nil {
+		t.Error("should've returned nil (cached)")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/TwiN/g8
 
-go 1.19
+go 1.20
 
 require github.com/TwiN/gocache/v2 v2.2.0


### PR DESCRIPTION
<!-- Thank you for contributing! -->

## Summary
<!-- If there's a relevant issue, you can just write the issue number below (e.g. #123) -->
Fixes #8

This PR does the following:
- Adds support for specifying a custom cache 
- Removes ClientProvider.StartCacheJanitor
- Removes ClientProvider.StopCacheJanitor

Work remaining left:
- [ ] Add documentation for the custom cache
- [ ] Update the module in go.mod from `github.com/TwiN/g8` to `github.com/TwiN/g8/v2`

## Checklist
<!-- Replace [ ] by [X] if you have completed the item -->
- [X] Tested and/or added tests to validate that the changes work as intended, if applicable.
- [ ] Added the documentation in `README.md`, if applicable.
